### PR TITLE
fix: focus can be hijacked into the plugin

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -9,7 +9,13 @@
 	<body>
 		<form action="#" method="get" class="search-form" name="searchForm">
 			<fieldset>
-				<input type="text" name="title" class="form-input title-input" placeholder="Søk" />
+				<input
+					type="text"
+					name="title"
+					class="form-input title-input"
+					placeholder="Søk"
+					autocomplete="off"
+				/>
 				<select name="period" class="form-input">
 					<option value="">Ingen tidsbegrensning</option>
 					<option value="today">I dag</option>

--- a/client/styles/search-form.css
+++ b/client/styles/search-form.css
@@ -8,6 +8,12 @@
 	border-radius: 1em;
 
 	padding: 6px 12px;
+	outline: none;
+}
+
+.form-input:focus,
+.form-input:active {
+	border: 1px solid #ffffff;
 }
 
 .form-input option {
@@ -18,6 +24,12 @@
 .title-input {
 	min-width: 360px;
 	margin-right: 6px;
+}
+
+.title-input:focus,
+.title-input:active {
+	background: #ffffff;
+	color: #000;
 }
 
 .category-toggle {

--- a/client/styles/search-form.css
+++ b/client/styles/search-form.css
@@ -28,6 +28,7 @@
 
 .title-input:focus,
 .title-input:active {
+	border: 1px solid #666666;
 	background: #ffffff;
 	color: #000;
 }

--- a/client/ui/index.js
+++ b/client/ui/index.js
@@ -104,9 +104,49 @@ async function init({ onTargetSelect, onTargetCancel }) {
 		}
 	})
 
+	setupFocusHandling()
+	setupKeyHandling()
+
 	return {
 		origin
 	}
+}
+
+/** Override some keyboard events, so that they don't trigger built-in browser behavior */
+function setupKeyHandling() {
+	document.addEventListener('keydown', (e) => {
+		if (e.code === 'Escape') {
+			// Allow the user to explicitly escape focus
+			blurPlugin()
+			e.preventDefault()
+		} else if (e.code.match(/^F(\d+)$/)) {
+			e.preventDefault()
+		}
+	})
+}
+
+/** This will inform the host application (we assume Sofie) that we may have hijacked the focus, and that it should
+ * take the focus back.
+ */
+function setupFocusHandling() {
+	document.addEventListener('focusout', (e) => {
+		if (
+			e.relatedTarget === null ||
+			e.relatedTarget.nodeName !== 'INPUT' ||
+			e.relatedTarget.nodeName !== 'SELECT' ||
+			e.relatedTarget.nodeName !== 'TEXTAREA'
+		) {
+			blurPlugin()
+		}
+	})
+}
+
+function blurPlugin() {
+	window.parent &&
+		window.parent.postMessage({
+			id: Date.now(),
+			type: 'focus_in'
+		})
 }
 
 function setupDragTracking(className, { onDragStart, onDragEnd }) {

--- a/client/ui/index.js
+++ b/client/ui/index.js
@@ -132,9 +132,9 @@ function setupFocusHandling() {
 	document.addEventListener('focusout', (e) => {
 		if (
 			e.relatedTarget === null ||
-			e.relatedTarget.nodeName !== 'INPUT' ||
-			e.relatedTarget.nodeName !== 'SELECT' ||
-			e.relatedTarget.nodeName !== 'TEXTAREA'
+			(e.relatedTarget.nodeName !== 'INPUT' &&
+				e.relatedTarget.nodeName !== 'SELECT' &&
+				e.relatedTarget.nodeName !== 'TEXTAREA')
 		) {
 			blurPlugin()
 		}

--- a/client/ui/index.js
+++ b/client/ui/index.js
@@ -144,7 +144,7 @@ function setupFocusHandling() {
 function blurPlugin() {
 	window.parent &&
 		window.parent.postMessage({
-			id: Date.now(),
+			id: `quantel-browser-plugin-${Date.now()}`,
 			type: 'focus_in'
 		})
 }


### PR DESCRIPTION
When using the plugin, focus can "stay behind" in the plugin, hijacking hotkeys from the main Sofie GUI. To avoid that: the search box will show it's focused state more clearly (like other search boxes in Sofie) & default Function key action will now be prevented. Also, when an input element is blurred in the plugin, the Host application will now be informed to take focus back.